### PR TITLE
Use firstMatch for `identifyingElement` lookup

### DIFF
--- a/Sources/Salad/ViewObject.swift
+++ b/Sources/Salad/ViewObject.swift
@@ -20,21 +20,10 @@ public protocol ViewObject {
 
 public extension ViewObject {
   var identifyingElement: XCUIElement {
-    element(identifyingElementId)
-  }
-
-  /// Searches the root element in its current state for the first child element with the given accessibility identifier.
-  ///
-  /// - Note: An `XCTest` assertion will fail when the `identifier` is missing.
-  ///
-  /// - Parameter identifier: The accessibility identifier to look up
-  /// - Returns: `XCUIElement` found using the given identifier
-  private func element(_ identifier: String) -> XCUIElement {
-    root.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    root.descendants(matching: .any).matching(identifier: identifyingElementId).firstMatch
   }
 
   func assertIdentifyingElementExists(timeout: TimeOut, file: StaticString = #file, line: UInt = #line) {
-    let elementToAssert = element(identifyingElementId)
-    XCTAssertTrue(elementToAssert.waitForExist(timeout: timeout), "Expected to be on view object '\(Self.self)', but identifying element '\(identifyingElementId)' does not exist. (Did wait for \(timeout.timeInterval) seconds)", file: file, line: line)
+    XCTAssertTrue(identifyingElement.waitForExist(timeout: timeout), "Expected to be on view object '\(Self.self)', but identifying element '\(identifyingElementId)' does not exist. (Did wait for \(timeout.timeInterval) seconds)", file: file, line: line)
   }
 }

--- a/Sources/Salad/ViewObject.swift
+++ b/Sources/Salad/ViewObject.swift
@@ -23,14 +23,14 @@ public extension ViewObject {
     element(identifyingElementId)
   }
 
-  /// Searches the root element in its current state for an unique child element with the given accessibility identifier.
+  /// Searches the root element in its current state for the first child element with the given accessibility identifier.
   ///
-  /// - Note: An `XCTest` assertion will fail when the `identifier` is missing or when there are multiple matches.
+  /// - Note: An `XCTest` assertion will fail when the `identifier` is missing.
   ///
   /// - Parameter identifier: The accessibility identifier to look up
   /// - Returns: `XCUIElement` found using the given identifier
-  func element(_ identifier: String) -> XCUIElement {
-    root.descendants(matching: .any).matching(identifier: identifier).element
+  private func element(_ identifier: String) -> XCUIElement {
+    root.descendants(matching: .any).matching(identifier: identifier).firstMatch
   }
 
   func assertIdentifyingElementExists(timeout: TimeOut, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
This is much faster according to this WWDC video: https://developer.apple.com/videos/play/wwdc2017/409/ (at 22 min)

It also changes behaviour, since now we would be okay with 2 of the same `identifyingElement`s on screen. Question is if we're okay with that change and less strict check.

Also made the method private since it was never used by Salad consumers, could also be inlined since it's only used at one place.

![Schermafbeelding 2020-07-03 om 00 50 07](https://user-images.githubusercontent.com/618233/86415379-28f6d400-bcc7-11ea-9ee0-d39ec261884f.png)