### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,4 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    # This is needed because Salad uses parts of XCTest that are not available to Swift packages 
-    - name: Generate Xcode project
-      run: swift package generate-xcodeproj
-    - name: Run tests
-      run: xcodebuild build test -scheme Salad-Package -project Salad.xcodeproj | xcpretty
+    - run: swift test


### PR DESCRIPTION
The command `swift package generate-xcodeproj` has been removed, so use `swift test` instead.